### PR TITLE
Move subscription button above plan selection cards

### DIFF
--- a/ZucchiniMVC/Views/Subscription/Index.cshtml
+++ b/ZucchiniMVC/Views/Subscription/Index.cshtml
@@ -12,8 +12,13 @@
 </div>
 
 <form method="post" action="/Subscription/Subscribe">
-    <div class="row justify-content-center">
-        <!-- Weekly Plan -->
+<div class="row mb-4">
+    <div class="col-12 text-center">
+        <button type="submit" class="btn btn-success btn-lg px-5 rounded-pill shadow">Complete Subscription</button>
+    </div>
+</div>
+<div class="row justify-content-center">
+    <!-- Weekly Plan -->
         <div class="col-md-4 mb-4">
             <div class="card h-100 shadow-sm border-0">
                 <div class="card-header bg-primary text-white text-center py-3">
@@ -74,12 +79,6 @@
                     </div>
                 </div>
             </div>
-        </div>
-    </div>
-    
-    <div class="row mt-3">
-        <div class="col-12 text-center">
-            <button type="submit" class="btn btn-success btn-lg px-5 rounded-pill shadow">Complete Subscription</button>
         </div>
     </div>
 </form>


### PR DESCRIPTION
The "Complete Subscription" button is now displayed above the subscription plan cards instead of below them, improving its visibility and prominence for users before they select a plan.