### PR TITLE
Optimize api client call

### DIFF
--- a/ZucchiniMVC/Application/Services/CMS/CmsService.cs
+++ b/ZucchiniMVC/Application/Services/CMS/CmsService.cs
@@ -1,7 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using ZucchiniCore.Entities;
-using Zucchinimvc.Infrastructure.Data;
 using Zucchinimvc.Infrastructure.Repositories.CmsRepo;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Zucchinimvc.Application.Services.CMS;
 
@@ -9,22 +9,24 @@ public class CmsService : ICmsService
 {
 
     private readonly ICmsRepository _cmsRepository;
-    public CmsService(ICmsRepository cmsRepository)
+        private readonly IMemoryCache _cache;
+    public CmsService(ICmsRepository cmsRepository, IMemoryCache cache)
     {
         _cmsRepository = cmsRepository;
-
+        _cache = cache;
     }
 
     public async Task<IEnumerable<Article>> GetArticles()
     {
-        var articles = await _cmsRepository.GetArticlesAsync();
+        return await _cache.GetOrCreateAsync(
+            "cms-articles",
+            async entry =>
+            {
+                entry.AbsoluteExpirationRelativeToNow =
+                    TimeSpan.FromMinutes(15);
 
-        foreach (var article in articles)
-        {
-            var totalContent = $"{article.BodyPreview} {article.BodyGated}";
-        }
-
-        return articles;
+                return await _cmsRepository.GetArticlesAsync();
+            }) ?? Enumerable.Empty<Article>();
     }
 
     public async Task<Article?> GetArticleBySlug(string slug)
@@ -47,7 +49,7 @@ public class CmsService : ICmsService
 
     public async Task<Article> GetFeaturedArticle()
     {
-        var articles = await _cmsRepository.GetArticlesAsync();
+        var articles = await GetArticles();
         Article? featured = null;
 
         try
@@ -73,14 +75,14 @@ public class CmsService : ICmsService
 
     public async Task<List<Article>> GetEditorsChoice()
     {
-        var articles = await _cmsRepository.GetArticlesAsync();
+        var articles = await GetArticles();
         return articles.Where(a => a.EditorsChoice).ToList();
     }
 
     public async Task<List<Article>> GetLatestArticles()
     {
         int take = 6;
-        var articles = await _cmsRepository.GetArticlesAsync();
+        var articles = await GetArticles();
         return articles
             .OrderByDescending(a => a.PublishedAt)
             .Take(take)

--- a/ZucchiniMVC/Application/Services/CMS/CmsService.cs
+++ b/ZucchiniMVC/Application/Services/CMS/CmsService.cs
@@ -9,7 +9,7 @@ public class CmsService : ICmsService
 {
 
     private readonly ICmsRepository _cmsRepository;
-        private readonly IMemoryCache _cache;
+    private readonly IMemoryCache _cache;
     public CmsService(ICmsRepository cmsRepository, IMemoryCache cache)
     {
         _cmsRepository = cmsRepository;

--- a/ZucchiniMVC/Application/Services/CMS/CmsService.cs
+++ b/ZucchiniMVC/Application/Services/CMS/CmsService.cs
@@ -37,8 +37,18 @@ public class CmsService : ICmsService
 
     public async Task<List<Category>> GetAllCategories()
     {
-        var categories = await _cmsRepository.GetCategoriesAsync();
-        return categories.ToList();
+        return await _cache.GetOrCreateAsync(
+        "cms-categories",
+        async entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow =
+                TimeSpan.FromHours(1);
+
+            var categories =
+                await _cmsRepository.GetCategoriesAsync();
+
+            return categories.ToList();
+        }) ?? new List<Category>();
     }
 
     public async Task<List<Article>> GetArticlesByCategory(string categorySlug)

--- a/ZucchiniMVC/Application/Services/Currency/CurrencyService.cs
+++ b/ZucchiniMVC/Application/Services/Currency/CurrencyService.cs
@@ -17,9 +17,6 @@ namespace Zucchinimvc.Application.Services.Currency
             _cache = cache;
         }
 
-        // Service returns DTO, not ViewModel
-
-
         public async Task<Dictionary<string, decimal>> GetLatestRatesAsync(string baseCurrency)
         {
             var cacheKey = $"currency_rates_{baseCurrency}";

--- a/ZucchiniMVC/Application/Services/Currency/CurrencyService.cs
+++ b/ZucchiniMVC/Application/Services/Currency/CurrencyService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using Zucchinimvc.Infrastructure.Repositories.CurrencyRepo;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Zucchinimvc.Application.Services.Currency
 {
@@ -7,11 +8,13 @@ namespace Zucchinimvc.Application.Services.Currency
     {
         private readonly ILogger<CurrencyService> _logger;
         private readonly ICurrencyRepository _currencyRepo;
+        private readonly IMemoryCache _cache;
 
-        public CurrencyService(ILogger<CurrencyService> logger, ICurrencyRepository currencyRepo)
+        public CurrencyService(ILogger<CurrencyService> logger, ICurrencyRepository currencyRepo, IMemoryCache cache)
         {
             _logger = logger;
             _currencyRepo = currencyRepo;
+            _cache = cache;
         }
 
         // Service returns DTO, not ViewModel
@@ -19,6 +22,14 @@ namespace Zucchinimvc.Application.Services.Currency
 
         public async Task<Dictionary<string, decimal>> GetLatestRatesAsync(string baseCurrency)
         {
+            var cacheKey = $"currency_rates_{baseCurrency}";
+
+            if (_cache.TryGetValue(cacheKey, out Dictionary<string, decimal> cachedRates))
+            {
+                _logger.LogInformation("Cache hit for {Base}", baseCurrency);
+                return cachedRates;
+            }
+
             var response = await _currencyRepo.GetLatestRatesAsync(baseCurrency);
 
             if (response?.Rates == null)
@@ -36,6 +47,15 @@ namespace Zucchinimvc.Application.Services.Currency
                     results.Add(rate.Key, val);
                 }
             }
+
+            var cacheOptions = new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(15),
+                SlidingExpiration = TimeSpan.FromMinutes(5)
+            };
+
+            _cache.Set(cacheKey, results, cacheOptions);
+            _logger.LogInformation("Cache set for {Base}", baseCurrency);
 
             return results;
         }

--- a/ZucchiniMVC/Application/Services/Weather/WeatherService.cs
+++ b/ZucchiniMVC/Application/Services/Weather/WeatherService.cs
@@ -3,6 +3,8 @@ using Zucchinimvc.Infrastructure.Repositories.HistoryRepo;
 using Zucchinimvc.Infrastructure.Repositories.WeatherRepo;
 using Zucchinimvc.Models.DTOs.WeatherDTOs;
 using Zucchinimvc.Models.ViewModels;
+using Microsoft.Extensions.Caching.Memory;
+using NuGet.Protocol;
 
 namespace Zucchinimvc.Application.Services.Weather;
 
@@ -10,16 +12,25 @@ public class WeatherService : IWeatherService
 {
     private readonly IWeatherRepository _weatherRepo;
     private readonly IHistoryRepository<WeatherHistoryEntity> _historyRepo;
+    private readonly IMemoryCache _cache;
 
-    public WeatherService(IWeatherRepository weatherRepo, IHistoryRepository<WeatherHistoryEntity> historyRepo)
+    public WeatherService(IWeatherRepository weatherRepo, IHistoryRepository<WeatherHistoryEntity> historyRepo, IMemoryCache cache)
     {
         _weatherRepo = weatherRepo;
         _historyRepo = historyRepo;
+        _cache = cache;
     }
 
     public async Task<WeatherViewModel?> GetWeatherByCityAsync(string city)
     {
         if (string.IsNullOrWhiteSpace(city)) return null;
+
+        var cacheKey = $"Weather_{city.Trim().ToLowerInvariant()}";
+
+        if (_cache.TryGetValue(cacheKey, out WeatherViewModel? cached))
+        {
+            return cached;
+        }
 
         var location = await _weatherRepo.GetCoordinatesAsync(city);
         if (location == null) return null;
@@ -27,7 +38,15 @@ public class WeatherService : IWeatherService
         var weather = await _weatherRepo.GetWeatherAsync(location.Lat, location.Lon);
         if (weather?.Main == null) return null;
 
-        return MapToViewModel(city, weather);
+        var viewModel = MapToViewModel(city, weather);
+
+        _cache.Set(cacheKey, viewModel, new MemoryCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(10),
+            SlidingExpiration = TimeSpan.FromMinutes(3)
+        });
+
+        return viewModel;
     }
 
     public async Task SaveWeatherHistoryAsync(WeatherViewModel model)
@@ -67,6 +86,12 @@ public class WeatherService : IWeatherService
     public async Task<WeatherViewModel?> GetWeatherAnalyticsAsync(string city)
     {
         var targetCity = string.IsNullOrWhiteSpace(city) ? "Linköping" : city;
+
+        var cacheKey = $"weather_analytics_{targetCity.Trim().ToLowerInvariant()}";
+
+        if (_cache.TryGetValue(cacheKey, out WeatherViewModel? cached))
+            return cached;
+
         var weather = await GetWeatherByCityAsync(targetCity);
 
         if (weather == null) return null;
@@ -85,6 +110,11 @@ public class WeatherService : IWeatherService
                 Temperatures = history.Select(x => x.Temperature).ToList()
             });
         }
+
+        _cache.Set(cacheKey, weather, new MemoryCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5)
+        });
 
         return weather;
     }

--- a/ZucchiniMVC/Application/Services/Weather/WeatherService.cs
+++ b/ZucchiniMVC/Application/Services/Weather/WeatherService.cs
@@ -4,7 +4,6 @@ using Zucchinimvc.Infrastructure.Repositories.WeatherRepo;
 using Zucchinimvc.Models.DTOs.WeatherDTOs;
 using Zucchinimvc.Models.ViewModels;
 using Microsoft.Extensions.Caching.Memory;
-using NuGet.Protocol;
 
 namespace Zucchinimvc.Application.Services.Weather;
 
@@ -93,8 +92,10 @@ public class WeatherService : IWeatherService
         var cacheKey = $"weather_analytics_{targetCity.Trim().ToLowerInvariant()}";
 
         if (_cache.TryGetValue(cacheKey, out WeatherViewModel? cached))
+        {
+            _logger.LogInformation("Cache hit analytics for {City}", targetCity);
             return cached;
-
+        }
         var weather = await GetWeatherByCityAsync(targetCity);
 
         if (weather == null) return null;
@@ -119,6 +120,7 @@ public class WeatherService : IWeatherService
             AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5)
         });
 
+        _logger.LogInformation("Cache set analytics for {City}", targetCity); 
         return weather;
     }
 

--- a/ZucchiniMVC/Application/Services/Weather/WeatherService.cs
+++ b/ZucchiniMVC/Application/Services/Weather/WeatherService.cs
@@ -12,13 +12,14 @@ public class WeatherService : IWeatherService
 {
     private readonly IWeatherRepository _weatherRepo;
     private readonly IHistoryRepository<WeatherHistoryEntity> _historyRepo;
-    private readonly IMemoryCache _cache;
-
-    public WeatherService(IWeatherRepository weatherRepo, IHistoryRepository<WeatherHistoryEntity> historyRepo, IMemoryCache cache)
+    private readonly IMemoryCache _cache; 
+    private readonly ILogger<WeatherService> _logger;
+    public WeatherService(IWeatherRepository weatherRepo, IHistoryRepository<WeatherHistoryEntity> historyRepo, IMemoryCache cache, ILogger<WeatherService> logger)
     {
         _weatherRepo = weatherRepo;
         _historyRepo = historyRepo;
         _cache = cache;
+        _logger = logger;
     }
 
     public async Task<WeatherViewModel?> GetWeatherByCityAsync(string city)
@@ -29,6 +30,7 @@ public class WeatherService : IWeatherService
 
         if (_cache.TryGetValue(cacheKey, out WeatherViewModel? cached))
         {
+            _logger.LogInformation("Cache hit for {City}", city); 
             return cached;
         }
 
@@ -46,6 +48,7 @@ public class WeatherService : IWeatherService
             SlidingExpiration = TimeSpan.FromMinutes(3)
         });
 
+        _logger.LogInformation("Cache set for {City}", city);
         return viewModel;
     }
 

--- a/ZucchiniMVC/Program.cs
+++ b/ZucchiniMVC/Program.cs
@@ -41,6 +41,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Logging.AddConsole();
 builder.Logging.SetMinimumLevel(LogLevel.Debug);
 
+// Framework services
+builder.Services.AddMemoryCache();
+
 // Register filter
 builder.Services.AddScoped<LayoutDataFilter>();
 
@@ -49,6 +52,7 @@ builder.Services.AddControllersWithViews(options =>
 {
     options.Filters.AddService<LayoutDataFilter>();
 }); 
+
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 builder.Services.AddRazorPages();


### PR DESCRIPTION
## Caching Implementation for CMS, Weather, and Currency Services

### Overview
Introduced in-memory caching across three services to reduce redundant external API calls
improve overall page load performance.

### Changes

**CurrencyService**
- Added cache layer in `GetLatestRatesAsync` with a 15-minute absolute expiration and 5-minute sliding expiration
- Cache is keyed per base currency (e.g. `currency_rates_USD`)
- Added `ILogger` with cache hit/miss logging for observability

**WeatherService**
- Added cache layer in `GetWeatherByCityAsync` with a 10-minute absolute expiration and 3-minute sliding expiration
- Added cache layer in `GetWeatherAnalyticsAsync` with a 5-minute absolute expiration
- Added `ILogger` with cache hit/miss logging on both methods

**CmsService**
- Added cache layer in `GetArticles` with a 15-minute absolute expiration
- Added cache layer in `GetAllCategories` with a 1-hour absolute expiration
- Methods that depend on `GetArticles` internally (`GetFeaturedArticle`, `GetEditorsChoice`, `GetLatestArticles`) benefit from caching automatically

### Impact
- Eliminates repeated calls to Weather, Currency, and CMS APIs on every page load
- Cache hits confirmed in application logs