### PR TITLE
Added: JS SDK tracker

### DIFF
--- a/ZucchiniMVC/Infrastructure/Repositories/AnalyticsRepo/AnalyticsRepository.cs
+++ b/ZucchiniMVC/Infrastructure/Repositories/AnalyticsRepo/AnalyticsRepository.cs
@@ -1,4 +1,5 @@
 using System.Configuration;
+using System.Diagnostics.Metrics;
 using Azure.Core;
 using Azure.Monitor.Query;
 using Zucchinimvc.Application.Services.Analytics.DTOs;
@@ -21,9 +22,11 @@ public class AnalyticsRepository : IAnalyticsRepository
     public async Task<(int Views, int UniqueVisitors)> GetSummaryAsync(DateTime from, DateTime to)
     {
         var query = $@"
-        requests
-        | where timestamp >= ago(30d)
-        | summarize TotalRequests = count(), UniqueUsers = dcount(user_Id)";
+            union requests, pageViews
+            | where timestamp >= ago(30d)
+            | summarize 
+                TotalRequests = countif(sdkVersion startswith 'a' or isnotempty(id)),
+                UniqueUsers = dcount(session_Id)";
 
         var response = await _logQueryClient.QueryResourceAsync(
             new ResourceIdentifier(_resourceId),

--- a/ZucchiniMVC/Views/Admin/_ManageUsers.cshtml
+++ b/ZucchiniMVC/Views/Admin/_ManageUsers.cshtml
@@ -10,6 +10,7 @@
             SubscriptionStatus.Pending => "badge bg-warning text-dark",
             SubscriptionStatus.PastDue => "badge bg-danger",
             SubscriptionStatus.Expired => "badge bg-dark",
+            SubscriptionStatus.Cancelled => "badge bg-dark text-red",
             _ => "badge bg-light text-dark"
         };
     }
@@ -40,7 +41,8 @@
                     <th>Email</th>
                     <th>First Name</th>
                     <th>Last Name</th>
-                    <th>Newsletter Subscribed</th>
+                    <th>Newsletter
+                        Subscriber</th>
                     <th>Stripe Status</th>
                     <th>Plan</th>
                 </tr>
@@ -57,7 +59,7 @@
                     <td>@user.FirstName</td>
                     <td>@user.LastName</td>
                     <td>@user.NewsletterSubscribed</td>
-                    <td>
+                    <td class="text-center">
                         @if (latestSub != null)
                         {
                             <span class="badge @GetStatusBadgeClass(latestSub.Status)">

--- a/ZucchiniMVC/Views/Shared/_AppInsights.cshtml
+++ b/ZucchiniMVC/Views/Shared/_AppInsights.cshtml
@@ -1,0 +1,25 @@
+@using Microsoft.Extensions.Configuration
+@inject IConfiguration Configuration
+
+@{
+    var connectionString = Configuration.GetConnectionString("ApplicationInsights") 
+                        ?? Configuration["ApplicationInsights:ConnectionString"];
+}
+
+<script src="https://js.monitor.azure.com/scripts/b/ai.2.min.js" crossorigin="anonymous"></script>
+
+<script type="text/javascript">
+    if (window.Microsoft && window.Microsoft.ApplicationInsights) {
+        var snippet = new window.Microsoft.ApplicationInsights.ApplicationInsights({
+            config: {
+                connectionString: "@connectionString"
+            }
+        });
+        // Load the tracking system and attach it to the window globally
+        window.appInsights = snippet.loadAppInsights();
+        window.appInsights.trackPageView();
+        console.log("AppInsights forced initialized successfully!");
+    } else {
+        console.error("Could not load AppInsights source file from CDN.");
+    }
+</script>

--- a/ZucchiniMVC/Views/Shared/_Layout.cshtml
+++ b/ZucchiniMVC/Views/Shared/_Layout.cshtml
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="~/Zucchinimvc.styles.css" asp-append-version="true" />
+    @await Html.PartialAsync("_AppInsights")
 </head>
 
 <body class="news-body d-flex flex-column min-vh-100">

--- a/ZucchiniMVC/Views/_ViewImports.cshtml
+++ b/ZucchiniMVC/Views/_ViewImports.cshtml
@@ -1,3 +1,4 @@
 ﻿@using Zucchinimvc
 @using Zucchinimvc.Models
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, Microsoft.ApplicationInsights.AspNetCore


### PR DESCRIPTION
## Session_Id tracking
Enhancement or bugfix to the *_unique users_* tracking, which previously always showed one. It had no way to differentiate between clients since Azure renders it all server side and it doesn't get stored in Insight correctly.


I've Implemented an JS SDK to send a tracker when you hit our page, which gets blocked by most ad-blockers which is fine. but we got minimal tracking of how many sessions we get now.
<img width="634" height="224" alt="image" src="https://github.com/user-attachments/assets/630c067b-40e9-457e-8c67-e00ff9a86761" />